### PR TITLE
Updated part3.yaml to match this year's node layout

### DIFF
--- a/part3.yaml
+++ b/part3.yaml
@@ -18,13 +18,13 @@ spec:
   etcdClusters:
   - cpuRequest: 200m
     etcdMembers:
-    - instanceGroup: master-europe-west3-a
+    - instanceGroup: master-europe-west1-b
       name: a
     memoryRequest: 100Mi
     name: main
   - cpuRequest: 100m
     etcdMembers:
-    - instanceGroup: master-europe-west3-a
+    - instanceGroup: master-europe-west1-b
       name: a
     memoryRequest: 100Mi
     name: events
@@ -35,7 +35,7 @@ spec:
     anonymousAuth: false
   kubernetesApiAccess:
   - 0.0.0.0/0
-  kubernetesVersion: 1.28.6
+  kubernetesVersion: 1.31.5
   masterPublicName: api.part3.k8s.local
   networking:
     kubenet: {}
@@ -44,12 +44,12 @@ spec:
   sshAccess:
   - 0.0.0.0/0
   subnets:
-  - name: europe-west3
-    region: europe-west3
+  - name: europe-west1
+    region: europe-west1
     type: Public
   topology:
     dns:
-      type: Public
+      type: None
     masters: public
     nodes: public
 
@@ -61,20 +61,20 @@ metadata:
   creationTimestamp: null
   labels:
     kops.k8s.io/cluster: part3.k8s.local
-  name: master-europe-west3-a
+  name: master-europe-west1-b
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240208
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250130
   machineType: e2-standard-2
   maxSize: 1
   minSize: 1
   nodeLabels:
     cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: master-europe-west3-a
+    kops.k8s.io/instancegroup: master-europe-west1-b
   role: Master
   subnets:
-  - europe-west3
+  - europe-west1
   zones:
-  - europe-west3-a
+  - europe-west1-b
 
 ---
 
@@ -86,19 +86,19 @@ metadata:
     kops.k8s.io/cluster: part3.k8s.local
   name: client-measure
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240208
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250130
   machineType: e2-standard-2
   maxSize: 1
   minSize: 1
   nodeLabels:
     cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: nodes-europe-west3-a
+    kops.k8s.io/instancegroup: nodes-europe-west1-b
     cca-project-nodetype: "client-measure"
   role: Node
   subnets:
-  - europe-west3
+  - europe-west1
   zones:
-  - europe-west3-a
+  - europe-west1-b
 ---
 
 apiVersion: kops.k8s.io/v1alpha2
@@ -109,19 +109,19 @@ metadata:
     kops.k8s.io/cluster: part3.k8s.local
   name: client-agent-a
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240208
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250130
   machineType: e2-standard-2
   maxSize: 1
   minSize: 1
   nodeLabels:
     cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: nodes-europe-west3-a
+    kops.k8s.io/instancegroup: nodes-europe-west1-b
     cca-project-nodetype: "client-agent-a"
   role: Node
   subnets:
-  - europe-west3
+  - europe-west1
   zones:
-  - europe-west3-a
+  - europe-west1-b
 
 ---
 
@@ -133,19 +133,19 @@ metadata:
     kops.k8s.io/cluster: part3.k8s.local
   name: client-agent-b
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240208
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250130
   machineType: e2-standard-4
   maxSize: 1
   minSize: 1
   nodeLabels:
     cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: nodes-europe-west3-a
+    kops.k8s.io/instancegroup: nodes-europe-west1-b
     cca-project-nodetype: "client-agent-b"
   role: Node
   subnets:
-  - europe-west3
+  - europe-west1
   zones:
-  - europe-west3-a
+  - europe-west1-b
 
 ---
 apiVersion: kops.k8s.io/v1alpha2
@@ -156,19 +156,19 @@ metadata:
     kops.k8s.io/cluster: part3.k8s.local
   name: node-a-2core
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240208
-  machineType: n2d-highcpu-2
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250130
+  machineType: e2-highmem-2
   maxSize: 1
   minSize: 1
   nodeLabels:
     cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: nodes-europe-west3-a
+    kops.k8s.io/instancegroup: nodes-europe-west1-b
     cca-project-nodetype: "node-a-2core"
   role: Node
   subnets:
-  - europe-west3
+  - europe-west1
   zones:
-  - europe-west3-a
+  - europe-west1-b
 
 ---
 apiVersion: kops.k8s.io/v1alpha2
@@ -177,21 +177,21 @@ metadata:
   creationTimestamp: null
   labels:
     kops.k8s.io/cluster: part3.k8s.local
-  name: node-b-4core
+  name: node-b-2core
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240208
-  machineType: n2d-highmem-4
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250130
+  machineType: n2-highcpu-2
   maxSize: 1
   minSize: 1
   nodeLabels:
     cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: nodes-europe-west3-a
-    cca-project-nodetype: "node-b-4core"
+    kops.k8s.io/instancegroup: nodes-europe-west1-b
+    cca-project-nodetype: "node-b-2core"
   role: Node
   subnets:
-  - europe-west3
+  - europe-west1
   zones:
-  - europe-west3-a
+  - europe-west1-b
 
 ---
 apiVersion: kops.k8s.io/v1alpha2
@@ -200,18 +200,42 @@ metadata:
   creationTimestamp: null
   labels:
     kops.k8s.io/cluster: part3.k8s.local
-  name: node-c-8core
+  name: node-c-4core
 spec:
-  image: ubuntu-os-cloud/ubuntu-2204-jammy-v20240208
-  machineType: e2-standard-8
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250130
+  machineType: c3-highcpu-4
   maxSize: 1
   minSize: 1
   nodeLabels:
     cloud.google.com/metadata-proxy-ready: "true"
-    kops.k8s.io/instancegroup: nodes-europe-west3-a
-    cca-project-nodetype: "node-c-8core"
+    kops.k8s.io/instancegroup: nodes-europe-west1-b
+    cca-project-nodetype: "node-c-4core"
+  role: Node
+  rootVolumeType: pd-ssd
+  subnets:
+  - europe-west1
+  zones:
+  - europe-west1-b
+
+---
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  creationTimestamp: null
+  labels:
+    kops.k8s.io/cluster: part3.k8s.local
+  name: node-d-4core
+spec:
+  image: ubuntu-os-cloud/ubuntu-2404-noble-amd64-v20250130
+  machineType: n2-standard-4
+  maxSize: 1
+  minSize: 1
+  nodeLabels:
+    cloud.google.com/metadata-proxy-ready: "true"
+    kops.k8s.io/instancegroup: nodes-europe-west1-b
+    cca-project-nodetype: "node-d-4core"
   role: Node
   subnets:
-  - europe-west3
+  - europe-west1
   zones:
-  - europe-west3-a
+  - europe-west1-b


### PR DESCRIPTION
- Updated zone from `europe-west3-a` to `europe-west1-b`.
- Updated Kubernetes version, Ubuntu version and DNS configuration.
- Updated nodes to:
  - `node-a-2core`: `e2-highmem-2`
  - `node-b-2core`: `n2-highcpu-2`
  - `node-c-4core`: `c3-highcpu-4`
  - `node-d-4core`: `n2-standard-4`
