### PR TITLE
Fix version of cloud-controller-manager

### DIFF
--- a/part1.yaml
+++ b/part1.yaml
@@ -52,6 +52,8 @@ spec:
       type: None
     masters: Public
     nodes: Public
+  cloudControllerManager:
+    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master@sha256:e125f4e6792978125546e64279a13de18fdf6b704edfec8400cac1254d3adf88
 
 ---
 

--- a/part2a.yaml
+++ b/part2a.yaml
@@ -52,6 +52,8 @@ spec:
       type: None
     masters: public
     nodes: public
+  cloudControllerManager:
+    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master@sha256:e125f4e6792978125546e64279a13de18fdf6b704edfec8400cac1254d3adf88
 
 ---
 

--- a/part2b.yaml
+++ b/part2b.yaml
@@ -52,6 +52,8 @@ spec:
       type: None
     masters: public
     nodes: public
+  cloudControllerManager:
+    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master@sha256:e125f4e6792978125546e64279a13de18fdf6b704edfec8400cac1254d3adf88
 
 ---
 

--- a/part3.yaml
+++ b/part3.yaml
@@ -52,6 +52,8 @@ spec:
       type: None
     masters: public
     nodes: public
+  cloudControllerManager:
+    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master@sha256:e125f4e6792978125546e64279a13de18fdf6b704edfec8400cac1254d3adf88
 
 ---
 

--- a/part4.yaml
+++ b/part4.yaml
@@ -52,6 +52,8 @@ spec:
       type: None
     masters: public
     nodes: public
+  cloudControllerManager:
+    image: gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:master@sha256:e125f4e6792978125546e64279a13de18fdf6b704edfec8400cac1254d3adf88
 
 ---
 


### PR DESCRIPTION
A few hours ago, the Kubernetes team pushed [this pull request](https://github.com/kubernetes/cloud-provider-gcp/pull/825) to Google Cloud registries, which appears to have broken students' cluster setups. The cloud-controller-manager pod crashes during startup, ending up in a CrashLoopBackOff state. The output of `kubectl logs -n kube-system cloud-controller-manager-[generated ID]` is:

```
flag provided but not defined: -allocate-node-cidrs

Usage of /go-runner:

  -also-stdout

     useful with log-file, log to standard output as well as the log file

  -log-file string

     If non-empty, save stdout to this file

  -redirect-stderr

     treat stderr same as stdout (default true)
```

`go-runner` is the executable from the `registry.k8s.io/build-image/go-runner` image, and despite the team setting `CMD ["/cloud-controller-manager"]` it seems like when kops runs the cloud-controller-manager container it actually runs the `go-runner` executable, and not the actual cloud-controller-manager, which is why the cloud-controller-manager-specific flag is not recognized.

Either way, this pull request should fix the error by just downgrading to a previous version of the cloud-controller-manager image. As of yet, nobody has reported issues on the image's repository.