### PR TITLE
Add OpenEvolve starter files

### DIFF
--- a/openevolve/config.yaml
+++ b/openevolve/config.yaml
@@ -1,0 +1,42 @@
+# By default, your evolution will run for 50 iterations; feel free to change this value as needed.
+# At any time, you can resume evolution from a specific checkpoint by providing the --checkpoint flag to openevolve-run.
+max_iterations: 50
+checkpoint_interval: 1 # Do not change this
+
+llm:
+  api_base: "https://api.swissai.cscs.ch/v1"
+  primary_model: "<your model>"
+  # Possible additional parameters to configure the LLM:
+  # temperature: 
+  # max_tokens: 
+  # timeout: 
+  # top_p: 
+
+prompt:
+  # Prompts to provide the LLM with. You can directly write the prompt in the config, e.g.
+  # system_message: |
+  #   You are an expert programmer tasked with optimizing the following code...
+  #
+  # Alternatively, you can create files containing the prompts, and reference them here, e.g.
+  # template_dir: "<path-to-prompt-directory>"
+  # system_message: "name_of_file"
+  #
+  # The system message will be the content of the file <path-to-prompt-directory>/name_of_file.txt
+
+# You can learn more about these and other parameters here: https://github.com/algorithmicsuperintelligence/openevolve/blob/main/configs/default_config.yaml
+database:
+  population_size: 200 # Do not change this
+  # Relevant parameters:
+  # num_islands: 
+  # elite_selection_ratio: 
+  # exploitation_ratio: 
+
+# Evaluator configuration
+evaluator:
+  cascade_evaluation: false
+  parallel_evaluations: 1
+  # Relevant parameters:
+  # timeout: 
+
+diff_based_evolution: true
+max_code_length: 50000

--- a/openevolve/evaluator.py
+++ b/openevolve/evaluator.py
@@ -1,0 +1,8 @@
+from openevolve.evaluation_result import EvaluationResult
+
+
+def evaluate(program_path: str) -> EvaluationResult:
+    """
+    Evaluate the evolved program at "program_path" and return an EvaluationResult object containing the evaluation metrics.
+    """
+    pass

--- a/openevolve/openevolve_collect.py
+++ b/openevolve/openevolve_collect.py
@@ -1,0 +1,133 @@
+import argparse
+import shutil
+from pathlib import Path
+
+SUBMISSION_DIR_NAME = "part_3_openevolve"
+
+
+def get_logs_dir(output_dir: Path) -> Path:
+    return output_dir / "logs"
+
+
+def ask_correct_log_file(log_files: list[Path]) -> Path:
+    for i, log_file in enumerate(log_files):
+        print(f"[{i}] {log_file}")
+    while True:
+        try:
+            choice = int(input("Enter the number of the correct log file: "))
+            if 0 <= choice < len(log_files):
+                print()
+                return log_files[choice]
+            else:
+                print("Invalid choice.")
+        except ValueError:
+            print("Invalid input. Please enter a number.")
+
+
+def find_last_checkpoint_dir(log_file: Path) -> Path:
+    checkpoint_str = None
+    with log_file.open() as f:
+        for line in f:
+            if "Saved checkpoint at iteration" in line:
+                try:
+                    checkpoint_str = (
+                        line.split("Saved checkpoint at iteration")[1]
+                        .split("to")[1]
+                        .strip()
+                    )
+                except IndexError:
+                    continue
+
+    if checkpoint_str is None:
+        raise ValueError(
+            f'No checkpoint directory found in {log_file}. Did you remove "checkpoint_interval" from the config file?'
+        )
+
+    return Path(checkpoint_str)
+
+
+def can_overwrite(path: Path) -> bool:
+    if not path.exists():
+        return True
+    choice = input(
+        f"Warning: {path} already exists. Do you want to overwrite it? [y/N] "
+    ).lower()
+    return choice == "y"
+
+
+def collect_results(submission_dir: Path, log_file: Path, checkpoint_dir: Path):
+    openevolve_submission_dir = submission_dir / SUBMISSION_DIR_NAME
+    openevolve_submission_dir.mkdir(exist_ok=True)
+
+    dest_log_path = openevolve_submission_dir / "log.log"
+    dest_checkpoint_path = openevolve_submission_dir / "checkpoint_latest"
+
+    if can_overwrite(dest_log_path):
+        shutil.copy(log_file, dest_log_path)
+    else:
+        print(f"Skipping copying log file to {dest_log_path}")
+
+    if can_overwrite(dest_checkpoint_path):
+        shutil.copytree(checkpoint_dir, dest_checkpoint_path, dirs_exist_ok=True)
+    else:
+        print(f"Skipping copying checkpoint directory to {dest_checkpoint_path}")
+
+    print(f"Results collected in {openevolve_submission_dir}")
+
+
+def main(output_dir: Path, submission_dir: Path):
+    log_dir = get_logs_dir(output_dir)
+    if not log_dir.exists():
+        print(
+            f"Logs directory {log_dir} does not exist. Please check whether the output directory path is correct."
+        )
+        return
+
+    log_files = list(log_dir.glob("*.log"))
+    if not log_files:
+        print(f"No log files found in {log_dir}. Did you run OpenEvolve?")
+        return
+
+    if len(log_files) > 1:
+        print(
+            f"Multiple files were found in {log_dir}. This is likely caused by multiple runs of OpenEvolve using the same output directory. You could have lost important data for the submission. Proceed with care. Please indicate the log file corresponding to the run you want to submit results for."
+        )
+        log_file = ask_correct_log_file(log_files)
+    else:
+        log_file = log_files[0]
+
+    print(f"Using log file: {log_file}")
+
+    try:
+        raw_checkpoint_path = find_last_checkpoint_dir(log_file)
+        if raw_checkpoint_path.is_absolute():
+            checkpoint_dir = raw_checkpoint_path
+        else:
+            checkpoint_dir = output_dir.parent / raw_checkpoint_path
+    except ValueError as e:
+        print(e)
+        return
+
+    print(f"Using checkpoint directory: {checkpoint_dir}.")
+    collect_results(submission_dir, log_file, checkpoint_dir)
+    print("Done!")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=f"""Collects results from OpenEvolve for project submission. Please use with care, and double-check the results before submission. If you encounter any issues, please get in touch with the course staff.
+        As a last resort, manual collection of the results is also possible by copying the log file and the latest checkpoint directory to the {SUBMISSION_DIR_NAME}/ directory in your submission folder. Take extra care to ensure that the correct log file and checkpoint directory are copied, especially when multiple runs of OpenEvolve were conducted using the same output directory. If in doubt, ask the course staff for help."""
+    )
+    parser.add_argument(
+        "output_dir",
+        type=str,
+        help="The output directory of OpenEvolve",
+    )
+    parser.add_argument(
+        "submission_dir",
+        type=str,
+        help="Path to the root of the project submission directory",
+    )
+    args = parser.parse_args()
+
+    main(Path(args.output_dir), Path(args.submission_dir))

--- a/openevolve/requirements.txt
+++ b/openevolve/requirements.txt
@@ -1,0 +1,1 @@
+openevolve==0.2.26


### PR DESCRIPTION
Adds the `openevolve/` directory, add template files and tools for students to get started with OpenEvolve.

Contains:
- `config.yaml`: provides template properties for students to define.
  - `api_base` is pre-set to the CSCS endpoint. 
  - `checkpoint_interval` is fixed to 1, to guarantee checkpoint generation, required for the final submission
  - `population_size` is set to a large number. This property tells OpenEvolve how many programs to maintain as possible exploration starting points. While a high values creates a theoretical trade-off in terms of convergence speed compared to keeping only the top-surviving programs, it makes sure that the entire evolution history is maintained. This way, both we and the students can analyze and investigate the complete process. This approach matches several examples in the GitHub repo, where `population_size >= max_iterations`.
- `openevolve_collect.py`: utility script to automate artifact collection for submission. It inspects the output directory provided by the student, extracts the log (asking for user's input if multiple are present), locates the latest checkpoint and copies the files to the submission folder. As many things might go wrong, it provides fallback instructions in the help message to guide students in manually copying the required files.
- `evaluator.py` + `requirements.txt`: Empty evaluator file, only containing the function signature as required by OpenEvolve. The requirements file contains the `openevolve` dev dependency required for the function's return type.